### PR TITLE
tickers for all markets

### DIFF
--- a/cexio/__init__.py
+++ b/cexio/__init__.py
@@ -77,6 +77,9 @@ class Api:
         :rtype : dict
         """
         return self.api_call('ticker', None, market)
+   
+    def tickers_for_all_pairs_by_markets(self, markets="BTC/USD"):
+        return self.api_call('tickers', {}, 0, markets)
 
     @property
     def balance(self):


### PR DESCRIPTION
Please include this function as added above, tickers_for_all_pairs_by_markets, It shows all the tickers at once and eliminates the need to loop through a list to get multiple tickers.