### PR TITLE
removed an element in the function return

### DIFF
--- a/cexio/__init__.py
+++ b/cexio/__init__.py
@@ -79,7 +79,7 @@ class Api:
         return self.api_call('ticker', None, market)
    
     def tickers_for_all_pairs_by_markets(self, markets="BTC/USD"):
-        return self.api_call('tickers', {}, 0, markets)
+        return self.api_call('tickers', {}, markets)
 
     @property
     def balance(self):


### PR DESCRIPTION
Since I tested the function with a custom api_call as below compared to the api_call definition in your code there was a small issue of having 1 more definition than required here.
""""
    def api_call(self, method, params={}, private=0, pair='', http_method=None):
        url = self.base_url + method + '/'

        if pair != '':
            url = url + pair + '/'

        if private == 1:  # add auth-data for non-public/private resources
            self.__nonce()
            params.update({'key': self.__api_key, 'signature': self.__signature(), 'nonce': self.__nonce_v})

        if http_method is None:
            http_method = 'POST' if private == 1 else 'GET'

        return self.__execute_request(url, params, http_method)
""""
removing 0 from the function return solved the issue. Please feel free to correct me if there is a better way to do it. without that 0 now it works perfectly.